### PR TITLE
Snapshot deploy on GH with source JARs

### DIFF
--- a/.github/workflows/maven_snapshot_deploy.yml
+++ b/.github/workflows/maven_snapshot_deploy.yml
@@ -1,0 +1,21 @@
+name: Maven Snapshot Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
+      - name: Build and Deploy package
+        run: mvn -B clean deploy --fae --file ops-client-sdk/pom.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ops-client-sdk/pom.xml
+++ b/ops-client-sdk/pom.xml
@@ -151,6 +151,19 @@ limitations under the License.IBM Confidential]]>
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -221,4 +234,11 @@ limitations under the License.IBM Confidential]]>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/IBM/open-prediction-service-hub</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/ops-client-sdk/pom.xml
+++ b/ops-client-sdk/pom.xml
@@ -239,6 +239,12 @@ limitations under the License.IBM Confidential]]>
             <id>github</id>
             <name>GitHub Packages</name>
             <url>https://maven.pkg.github.com/IBM/open-prediction-service-hub</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
This proposal will add:

- Source JAR(s) to the `ops-client-sdk`; this way, an user importing it as dependency, can have easy access to the original source code
- Publish snapshot artifacts from `main` into the GH maven Package for _this_ repository; this way, an user can easily access a snapshot dependency for demo purposes without having to build this project manually and separately

/cc @mathieu what do you think, please?

---
Check list

- [ ] added a changelog entry
- [ ] referenced an issue

Can be merged if main build is passing : [![Build Status](https://travis-ci.com/IBM/open-prediction-service-hub.svg?branch=main)](https://travis-ci.com/IBM/open-prediction-service-hub)